### PR TITLE
First pass at converting UA Digital > AZ Digital for old static landing page.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -26,7 +26,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-xs-12 col-md-8">
-                    <h1>UA Digital <small>UA branding assets for the web</small></h1>
+                    <h1>Arizona Digital <small>UArizona branding assets for the web</small></h1>
                 </div>
             </div>
         </div>
@@ -35,22 +35,22 @@
         <div class="container">
         <div class="row">
             <div class="col-md-6">
-                <p><a href="ua-bootstrap" class="btn btn-default btn-lg btn-block">UA Bootstrap</a></p>
-                <p>UA Bootstrap is the University of Arizona's flavor of Bootstrap (aka "Twitter Bootstrap"), a popular HTML, CSS, and JS framework for developing responsive, mobile first projects on the web. If you're looking to adopt consistent styling of web elements, this is the best place to start.</p>
+                <p><a href="ua-bootstrap" class="btn btn-default btn-lg btn-block">Arizona Bootstrap</a></p>
+                <p>Build responsive, mobile-first projects on the web with the University of Arizona's theme for Bootstrap.</p>
             </div>
             <div class="col-md-6">
-                <p><a href="https://quickstart.arizona.edu/" class="btn btn-primary btn-lg btn-block">UA Quickstart</a></p>
-                <p>Looking for a preconfigured version of Drupal? UA Quickstart is just that — a Drupal distribution and install profile intended to provide a foundation for developers building Drupal-based sites. UA Bootstrap provides a portion of the frontend styles found within UA Quickstart.</p>
+                <p><a href="https://quickstart.arizona.edu/" class="btn btn-primary btn-lg btn-block">Arizona Quickstart</a></p>
+                <p>Looking for a preconfigured version of Drupal? Arizona Quickstart is just that — a Drupal distribution and install profile intended to provide a foundation for developers building Drupal-based sites. Arizona Bootstrap provides a portion of the frontend styles found within Arizona Quickstart.</p>
             </div>
         </div>
     <p>
     <h3>Get Involved</h2>
-    A team of web-focused volunteers known as UA Digital meets weekly to build and test products like <a href="/ua-bootstrap">UA Bootstrap</a> and <a href="https://quickstart.arizona.edu/">UA Quickstart.</a>
+    A team of web-focused volunteers known as Arizona Digital meets weekly to build and test products like <a href="/ua-bootstrap">Arizona Bootstrap</a> and <a href="https://quickstart.arizona.edu/">Arizona Quickstart.</a>
     </p><p>
     <ul>
-        <li>Request an invite to the Friday UA Digital meetings by subscribing to the <a href="https://list.arizona.edu/sympa/info/ua-digital">UA Digital listserv</a></li>
-        <li>Join the UA Digital discussions on <a href="https://uarizona.slack.com/messages/ua-bootstrap">Slack</a></li>
-        <li>Submit pull requests on <a href="https://bitbucket.org/uadigital/ua-bootstrap">Bitbucket</a></li>
+        <li>Request an invite to the Friday Arizona Digital meetings by subscribing to the <a href="https://list.arizona.edu/sympa/info/ua-digital">UA Digital listserv</a></li>
+        <li>Join the Arizona Digital discussions on <a href="https://uarizona.slack.com/messages/ua-bootstrap">Slack</a></li>
+        <li>Submit pull requests on <a href="https://github.com/az-digital">GitHub</a></li>
     </ul>
     </p>
     <p>


### PR DESCRIPTION
Kevin copied the content from uadigital.arizona.edu onto a new GitHub pages powered site at available at digitial.arizona.edu (using this repo).  This is quick attempt to update some of the content from UA -> AZ.  It might be better to rebuild the page altogether but maybe this can hold us over?