### PR TITLE
Update various links on https://digital.arizona.edu.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>UA Digital</title>
+    <title>Arizona Digital</title>
     <!-- UA Brand Icons, Usually requires https to load it. Best to use //brand.arizona.edu and reference from FQDN -->
     <link href="https://cdn.uadigital.arizona.edu/lib/ua-brand-icons/latest/ua-brand-icons.css" rel="stylesheet">
     <!-- UA Bootstrap -->
@@ -45,11 +45,11 @@
         </div>
     <p>
     <h3>Get Involved</h2>
-    A team of web-focused volunteers known as Arizona Digital meets weekly to build and test products like <a href="/ua-bootstrap">Arizona Bootstrap</a> and <a href="https://quickstart.arizona.edu/">Arizona Quickstart.</a>
+    A team of web-focused volunteers known as Arizona Digital meets weekly to build and test products like <a href="arizona-bootstrap">Arizona Bootstrap</a> and <a href="https://quickstart.arizona.edu/">Arizona Quickstart.</a>
     </p><p>
     <ul>
         <li>Request an invite to the Friday Arizona Digital meetings by subscribing to the <a href="https://list.arizona.edu/sympa/info/ua-digital">UA Digital listserv</a></li>
-        <li>Join the Arizona Digital discussions on <a href="https://uarizona.slack.com/messages/ua-bootstrap">Slack</a></li>
+        <li>Join the Arizona Digital discussions on <a href="https://quickstart.arizona.edu/join-us-on-slack">Slack</a></li>
         <li>Submit pull requests on <a href="https://github.com/az-digital">GitHub</a></li>
     </ul>
     </p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -35,7 +35,7 @@
         <div class="container">
         <div class="row">
             <div class="col-md-6">
-                <p><a href="ua-bootstrap" class="btn btn-default btn-lg btn-block">Arizona Bootstrap</a></p>
+                <p><a href="arizona-bootstrap" class="btn btn-default btn-lg btn-block">Arizona Bootstrap</a></p>
                 <p>Build responsive, mobile-first projects on the web with the University of Arizona's theme for Bootstrap.</p>
             </div>
             <div class="col-md-6">


### PR DESCRIPTION
The "Arizona Bootstrap" button/link on https://digital.arizona.edu currently points to UA Bootstrap.  We now have production documentation for Arizona Bootstrap we can link to instead.