### PR TITLE
arizona-digital/arizona-bootstrap#567: Use bot user token instead of old SSH key to push changes back to repo.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
-          ssh-key: ${{ secrets.SELF_DEPLOY_KEY }}
+          token: ${{ secrets.REPO_DISPATCH_TOKEN }}
 
       - name: Build variables
         run: |
@@ -28,7 +28,7 @@ jobs:
           echo "AZ_BOOTSTRAP_SCRIPTS_PATH=${clonedir}/scripts/*" >> ${GITHUB_ENV}
 
       - name: Get new updates from arizona-bootstrap
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: az-digital/arizona-bootstrap
           path: ${{ env.AZ_BOOTSTRAP_CLONE_DIR }}


### PR DESCRIPTION
Also updates all instances of actions/checkout with v3.