### PR TITLE
Closes #54: make distinct v2 and v5 subdirectories for Arizona Bootstrap branches.

### DIFF
--- a/.github/workflows/deploy-docs-for-v2-release.yml
+++ b/.github/workflows/deploy-docs-for-v2-release.yml
@@ -15,11 +15,11 @@ on:
 jobs:
   release:
     name: Create Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: az-digital/digital.arizona.edu
           token: ${{ secrets.REPO_DISPATCH_TOKEN }}
@@ -27,7 +27,7 @@ jobs:
         run: |
           stem='arizona-bootstrap'
           clonedir='arizona-bootstrap'
-          echo "AZ_REVIEW_BASEURL=/${stem}" >> ${GITHUB_ENV}
+          echo "AZ_REVIEW_BASEURL=/${stem}/v2" >> ${GITHUB_ENV}
           echo "AZ_SITE_HOST=https://digital.arizona.edu" >> ${GITHUB_ENV}
           echo "AZ_BOOTSTRAP_CLONE_DIR=${clonedir}" >> ${GITHUB_ENV}
           echo "AZ_BOOTSTRAP_CLONE_FULL_PATH=${GITHUB_WORKSPACE}/${clonedir}" >> ${GITHUB_ENV}
@@ -36,7 +36,7 @@ jobs:
           echo "AZ_BOOTSTRAP_PACKAGE_LOCK_PATH=${clonedir}/package-lock.json" >> ${GITHUB_ENV}
           echo "AZ_BOOTSTRAP_SCRIPTS_PATH=${clonedir}/scripts/*" >> ${GITHUB_ENV}
       - name: Get new updates from arizona-bootstrap
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: az-digital/arizona-bootstrap
           path: ${{ env.AZ_BOOTSTRAP_CLONE_DIR }}
@@ -55,16 +55,7 @@ jobs:
           echo "AZ_EPHEMERAL_IMAGE=${imagestem}${oldhash}" >> ${GITHUB_ENV}
           echo "AZ_BOOTSTRAP_SOURCE_DIR=arizona-bootstrap-source" >> ${GITHUB_ENV}
           echo "AZ_BOOTSTRAP_FROZEN_DIR=/azbuild/arizona-bootstrap" >> ${GITHUB_ENV}
-      - name: Docker authentication
-        run: |
-          docker login "$AZ_DOCKER_REGISTRY" -u "$GITHUB_ACTOR" -p ${{ secrets.GITHUB_TOKEN }}
-      - name: Search for Docker image
-        id: dockerpull
-        continue-on-error: true
-        run: |
-          docker pull "$AZ_EPHEMERAL_IMAGE"
-      - name: Conditionally rebuild the Docker image
-        if: ${{ steps.dockerpull.outcome == 'failure' }}
+      - name: Unonditionally rebuild the Docker image
         run: |
           workingtitle=$(docker build -q "$AZ_BOOTSTRAP_CLONE_FULL_PATH")
           tempname="old${AZ_OLD_HASH}"

--- a/.github/workflows/deploy-docs-for-v2-release.yml
+++ b/.github/workflows/deploy-docs-for-v2-release.yml
@@ -55,7 +55,7 @@ jobs:
           echo "AZ_EPHEMERAL_IMAGE=${imagestem}${oldhash}" >> ${GITHUB_ENV}
           echo "AZ_BOOTSTRAP_SOURCE_DIR=arizona-bootstrap-source" >> ${GITHUB_ENV}
           echo "AZ_BOOTSTRAP_FROZEN_DIR=/azbuild/arizona-bootstrap" >> ${GITHUB_ENV}
-      - name: Unonditionally rebuild the Docker image
+      - name: Unconditionally rebuild the Docker image
         run: |
           workingtitle=$(docker build -q "$AZ_BOOTSTRAP_CLONE_FULL_PATH")
           tempname="old${AZ_OLD_HASH}"

--- a/.github/workflows/deploy-docs-for-v5-release.yml
+++ b/.github/workflows/deploy-docs-for-v5-release.yml
@@ -15,17 +15,17 @@ on:
 jobs:
   release:
     name: Create Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.REPO_DISPATCH_TOKEN }}
       - name: Build variables
         run: |
           stem='arizona-bootstrap'
           clonedir='arizona-bootstrap'
-          echo "AZ_REVIEW_BASEURL=/${stem}" >> ${GITHUB_ENV}
+          echo "AZ_REVIEW_BASEURL=/${stem}/v5" >> ${GITHUB_ENV}
           echo "AZ_SITE_HOST=https://digital.arizona.edu" >> ${GITHUB_ENV}
           echo "AZ_BOOTSTRAP_CLONE_DIR=${clonedir}" >> ${GITHUB_ENV}
           echo "AZ_BOOTSTRAP_CLONE_FULL_PATH=${GITHUB_WORKSPACE}/${clonedir}" >> ${GITHUB_ENV}
@@ -34,7 +34,7 @@ jobs:
           echo "AZ_BOOTSTRAP_PACKAGE_LOCK_PATH=${clonedir}/package-lock.json" >> ${GITHUB_ENV}
           echo "AZ_BOOTSTRAP_SCRIPTS_PATH=${clonedir}/scripts/*" >> ${GITHUB_ENV}
       - name: Get new updates from arizona-bootstrap
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: az-digital/arizona-bootstrap
           path: ${{ env.AZ_BOOTSTRAP_CLONE_DIR }}
@@ -52,16 +52,7 @@ jobs:
           echo "AZ_EPHEMERAL_IMAGE=${imagestem}${oldhash}" >> ${GITHUB_ENV}
           echo "AZ_BOOTSTRAP_SOURCE_DIR=arizona-bootstrap-source" >> ${GITHUB_ENV}
           echo "AZ_BOOTSTRAP_FROZEN_DIR=/azbuild/arizona-bootstrap" >> ${GITHUB_ENV}
-      - name: Docker authentication
-        run: |
-          docker login "$AZ_DOCKER_REGISTRY" -u "$GITHUB_ACTOR" -p ${{ secrets.GITHUB_TOKEN }}
-      - name: Search for Docker image
-        id: dockerpull
-        continue-on-error: true
-        run: |
-          docker pull "$AZ_EPHEMERAL_IMAGE"
-      - name: Conditionally rebuild the Docker image
-        if: ${{ steps.dockerpull.outcome == 'failure' }}
+      - name: Unconditionally rebuild the Docker image
         run: |
           workingtitle=$(docker build -q "$AZ_BOOTSTRAP_CLONE_FULL_PATH")
           tempname="old${AZ_OLD_HASH}"
@@ -81,7 +72,6 @@ jobs:
           rsync --recursive --delete "${AZ_BOOTSTRAP_CLONE_DIR}/_site/" "docs${AZ_REVIEW_BASEURL}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global user.name "${GITHUB_ACTOR}"
-          git restore "docs${AZ_REVIEW_BASEURL}/docs/2.0/."
-          git add docs
+          git add "docs${AZ_REVIEW_BASEURL}"
           git commit -m "Arizona Bootstrap documentation updates for ${{ inputs.version }}"
           git push


### PR DESCRIPTION
This also simplifies the GitHub Actions document deployment workflows, skipping the use of the container registry, and bumps the version number on one Action.