### PR TITLE
Closes #73: Update Get Involved section with new layout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -214,7 +214,7 @@
           </div>
           <div class="col-md-6 pb-3">
             <div class="card card-body h-100"><h3 class="card-title h4">Arizona Digital UX</h3>
-              <p>The Arizona Digital UX team meets every other week to create the university's design system, collaborate with brand on new designs, and ensure functionality is usable on many platforms.</p>
+              <p>The Arizona Digital UX team meets every other week to create the university's design system, collaborate with Brand on new designs, and ensure a cohesive, user-friendly experience across platforms.</p>
               <ul>
                 <li>Join the <a href="https://arizona.zoom.us/my/azdigital">biweekly Zoom meetings</a> at 10am on Tuesdays</li>
                 <li>Chat on <a href="https://teams.microsoft.com/l/channel/19%3A5080e51bfa004dcdb6bf2417e6b28f6c%40thread.tacv2/User%20Experience?groupId=56dd8bd6-c065-4f07-bef0-9293bb01f97f&amp;tenantId=5ee35505-eb8e-4929-937d-645df5013288">Teams</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -196,15 +196,34 @@
     <div class="background-wrapper bg-cool-gray py-6">
       <div class="container">
         <div class="row">
-          <div class="col-12">
+          <div class="col">
             <h2 class="mt-0">Get Involved</h2>
-            <p>The Arizona Digital team meets weekly to build and test products like <a href="arizona-bootstrap">Arizona
-                Bootstrap</a> and <a href="https://quickstart.arizona.edu/">Arizona Quickstart</a>.</p>
-            <ul>
-              <li>Join the <a href="https://arizona.zoom.us/my/azdigital">Friday Zoom meetings</a> from 10am–Noon.</li>
-              <li>Chat on <a href="https://teams.microsoft.com/l/team/19%3A-MwdU6fBIuJVWL2G4F0NmFMqxrJ8kms2-qW5y3qCPe41%40thread.tacv2/conversations?groupId=56dd8bd6-c065-4f07-bef0-9293bb01f97f&tenantId=5ee35505-eb8e-4929-937d-645df5013288">Teams</a></li>
-              <li>Contribute via <a href="https://github.com/az-digital">GitHub</a></li>
-            </ul>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-md-6 pb-3">
+            <div class="card card-body h-100"><h3 class="card-title h4">Arizona Digital Dev</h3>
+              <p>The Arizona Digital team meets weekly to build and test products like <a href="arizona-bootstrap">Arizona
+                  Bootstrap</a> and <a href="https://quickstart.arizona.edu/">Arizona Quickstart</a>.</p>
+              <ul>
+                <li>Join the <a href="https://arizona.zoom.us/my/azdigital">Friday Zoom meetings</a> from 10am–Noon.</li>
+                <li>Chat on <a href="https://teams.microsoft.com/l/team/19%3A-MwdU6fBIuJVWL2G4F0NmFMqxrJ8kms2-qW5y3qCPe41%40thread.tacv2/conversations?groupId=56dd8bd6-c065-4f07-bef0-9293bb01f97f&amp;tenantId=5ee35505-eb8e-4929-937d-645df5013288">Teams</a></li>
+                <li>Contribute via <a href="https://github.com/az-digital">GitHub</a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="col-md-6 pb-3">
+            <div class="card card-body h-100"><h3 class="card-title h4">Arizona Digital UX</h3>
+              <p>The Arizona Digital UX team meets every other week to create the university's design system, collaborate with brand on new designs, and ensure functionality is usable on many platforms.</p>
+              <ul>
+                <li>Join the <a href="https://arizona.zoom.us/my/azdigital">biweekly Zoom meetings</a> at 10am on Tuesdays</li>
+                <li>Chat on <a href="https://teams.microsoft.com/l/channel/19%3A5080e51bfa004dcdb6bf2417e6b28f6c%40thread.tacv2/User%20Experience?groupId=56dd8bd6-c065-4f07-bef0-9293bb01f97f&amp;tenantId=5ee35505-eb8e-4929-937d-645df5013288">Teams</a></li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col">
             <p>Questions? Email <a href="mailto:az-digital@web.arizona.edu">az-digital@web.arizona.edu</a></p>
           </div>
         </div>


### PR DESCRIPTION
Closes #73 

Updates the homepage with a new section for the UX team in addition to the Dev team.
<img width="1379" height="446" alt="Screenshot 2026-08-06 at 9 44 13 AM" src="https://github.com/user-attachments/assets/93b37f83-8ac7-40b4-b025-305c495558b7" />
